### PR TITLE
:bug: Broken link to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The following options are supported:
  - `baseUrl`: URL to DAWA, defaults to `https://api.dataforsyningen.dk/adreser`.
  - `adgangsadresserOnly`: The user enters an access address, not a complete address with floor/suite. Defaults to `false`.
  - `fuzzy`: Whether fuzzy searching is enabled, defaults to `true`.
- - `params`: A JavaScript object containing any additional parameters to send to DAWA, e.g. `{kommunekode: "101"}`. Any parameter supported by the API can be specified. Please see check the [API docs](https://dawa.dataforsyningen.dk/dok/api/autocomplete#autocomplete) for further information:
+ - `params`: A JavaScript object containing any additional parameters to send to DAWA, e.g. `{kommunekode: "101"}`. Any parameter supported by the API can be specified. Please see check the [API docs](https://dawadocs.dataforsyningen.dk/dok/api/autocomplete#autocomplete) for further information:
  - `stormodtagerpostnumre`: Whether "stormodtagerpostnumre" will be displayed in suggestions. Defaults to `true`.
  - `minLength`: Number of characters which must be entered before any suggestions is displayed. Defaults to `2`.
  - `multiline`: Display address suggestions on multiple lines. Default `false`.


### PR DESCRIPTION
In the *Options* section the link to the API docs is broken.